### PR TITLE
feat: support at rule versions of import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This is broken into its own module in case the behaviour needs to be replicated 
 (i.e. [CSS Modules Values](https://github.com/css-modules/postcss-modules-values))
 
 ```js
-import { replaceSymbols, replaceValueSymbols } from 'icss-utils'
+import { replaceSymbols, replaceValueSymbols } from "icss-utils";
 
-replaceSymbols(css, replacements)
-replaceValueSymbols(string, replacements)
+replaceSymbols(css, replacements);
+replaceValueSymbols(string, replacements);
 ```
 
 Where:
@@ -31,8 +31,8 @@ A symbol is a string of alphanumeric, `-` or `_` characters. A replacement can b
 Extracts and remove (if removeRules is equal true) from PostCSS tree `:import`, `@icss-import`, `:export` and `@icss-export` statements.
 
 ```js
-import postcss from 'postcss'
-import { extractICSS } from 'icss-utils'
+import postcss from "postcss";
+import { extractICSS } from "icss-utils";
 
 const css = postcss.parse(`
   :import(colors) {
@@ -41,9 +41,9 @@ const css = postcss.parse(`
   :export {
     c: d;
   }
-`)
+`);
 
-extractICSS(css)
+extractICSS(css);
 /*
   {
     icssImports: {
@@ -69,16 +69,16 @@ Converts icss imports and exports definitions to postcss ast
 createICSSRules(
   {
     colors: {
-      a: 'b',
+      a: "b",
     },
   },
   {
-    c: 'd',
+    c: "d",
   },
   // Need pass `rule` and `decl` from postcss
   // Please look at `Step 4` https://evilmartians.com/chronicles/postcss-8-plugin-migration
-  postcss,
-)
+  postcss
+);
 ```
 
 By default it will create pseudo selector rules (`:import` and `:export`). Pass

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ extractICSS(css);
 By default both the pseudo and at-rule form of the import and export statements
 will be removed. Pass the `mode` option to limit to only one type.
 
-## createICSSRules(icssImports, icssExports, asAtRule = false)
+## createICSSRules(icssImports, icssExports, mode = 'rule')
 
 Converts icss imports and exports definitions to postcss ast
 
@@ -82,7 +82,7 @@ createICSSRules(
 ```
 
 By default it will create pseudo selector rules (`:import` and `:export`). Pass
-`true` for `asAtRule` to instead generate `@icss-import` and `@icss-export`, which
+`atrule` for `mode` to instead generate `@icss-import` and `@icss-export`, which
 may be more resilient to post processing by other tools.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This is broken into its own module in case the behaviour needs to be replicated 
 (i.e. [CSS Modules Values](https://github.com/css-modules/postcss-modules-values))
 
 ```js
-import { replaceSymbols, replaceValueSymbols } from "icss-utils";
+import { replaceSymbols, replaceValueSymbols } from 'icss-utils'
 
-replaceSymbols(css, replacements);
-replaceValueSymbols(string, replacements);
+replaceSymbols(css, replacements)
+replaceValueSymbols(string, replacements)
 ```
 
 Where:
@@ -26,13 +26,13 @@ A symbol is a string of alphanumeric, `-` or `_` characters. A replacement can b
 - In the value of a declaration, i.e. `color: my_symbol;` or `box-shadow: 0 0 blur spread shadow-color`
 - In a media expression i.e. `@media small {}` or `@media screen and not-large {}`
 
-## extractICSS(css, removeRules = true)
+## extractICSS(css, removeRules = true, mode = 'auto')
 
-Extracts and remove (if removeRules is equal true) from PostCSS tree `:import` and `:export` statements.
+Extracts and remove (if removeRules is equal true) from PostCSS tree `:import`, `@icss-import`, `:export` and `@icss-export` statements.
 
 ```js
-import postcss from "postcss";
-import { extractICSS } from "icss-utils";
+import postcss from 'postcss'
+import { extractICSS } from 'icss-utils'
 
 const css = postcss.parse(`
   :import(colors) {
@@ -41,9 +41,9 @@ const css = postcss.parse(`
   :export {
     c: d;
   }
-`);
+`)
 
-extractICSS(css);
+extractICSS(css)
 /*
   {
     icssImports: {
@@ -58,7 +58,10 @@ extractICSS(css);
 */
 ```
 
-## createICSSRules(icssImports, icssExports)
+By default both the pseudo and at-rule form of the import and export statements
+will be removed. Pass the `mode` option to limit to only one type.
+
+## createICSSRules(icssImports, icssExports, asAtRule = false)
 
 Converts icss imports and exports definitions to postcss ast
 
@@ -66,17 +69,21 @@ Converts icss imports and exports definitions to postcss ast
 createICSSRules(
   {
     colors: {
-      a: "b",
+      a: 'b',
     },
   },
   {
-    c: "d",
+    c: 'd',
   },
   // Need pass `rule` and `decl` from postcss
   // Please look at `Step 4` https://evilmartians.com/chronicles/postcss-8-plugin-migration
-  postcss
-);
+  postcss,
+)
 ```
+
+By default it will create pseudo selector rules (`:import` and `:export`). Pass
+`true` for `asAtRule` to instead generate `@icss-import` and `@icss-export`, which
+may be more resilient to post processing by other tools.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "url": "https://github.com/css-modules/icss-utils/issues"
   },
   "homepage": "https://github.com/css-modules/icss-utils#readme",
+  "prettier": {},
   "devDependencies": {
     "coveralls": "^3.1.0",
     "eslint": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "url": "https://github.com/css-modules/icss-utils/issues"
   },
   "homepage": "https://github.com/css-modules/icss-utils#readme",
-  "prettier": {},
   "devDependencies": {
     "coveralls": "^3.1.0",
     "eslint": "^7.9.0",

--- a/src/createICSSRules.js
+++ b/src/createICSSRules.js
@@ -59,9 +59,9 @@ const createExports = (exports, postcss, mode = "rule") => {
   return [rule];
 };
 
-const createICSSRules = (imports, exports, postcss, asAtRule) => [
-  ...createImports(imports, postcss, asAtRule),
-  ...createExports(exports, postcss, asAtRule),
+const createICSSRules = (imports, exports, postcss, mode) => [
+  ...createImports(imports, postcss, mode),
+  ...createExports(exports, postcss, mode),
 ];
 
 module.exports = createICSSRules;

--- a/src/createICSSRules.js
+++ b/src/createICSSRules.js
@@ -1,65 +1,65 @@
 const createImports = (imports, postcss, asAtRule) => {
   return Object.keys(imports).map((path) => {
-    const aliases = imports[path]
+    const aliases = imports[path];
     const declarations = Object.keys(aliases).map((key) =>
       postcss.decl({
         prop: key,
         value: aliases[key],
-        raws: { before: '\n  ' },
-      }),
-    )
+        raws: { before: "\n  " },
+      })
+    );
 
-    const hasDeclarations = declarations.length > 0
+    const hasDeclarations = declarations.length > 0;
 
     const rule = !asAtRule
       ? postcss.rule({
           selector: `:import('${path}')`,
-          raws: { after: hasDeclarations ? '\n' : '' },
+          raws: { after: hasDeclarations ? "\n" : "" },
         })
       : postcss.atRule({
-          name: 'icss-import',
+          name: "icss-import",
           params: `'${path}'`,
-          raws: { after: hasDeclarations ? '\n' : '' },
-        })
+          raws: { after: hasDeclarations ? "\n" : "" },
+        });
 
     if (hasDeclarations) {
-      rule.append(declarations)
+      rule.append(declarations);
     }
 
-    return rule
-  })
-}
+    return rule;
+  });
+};
 
 const createExports = (exports, postcss, asAtRule) => {
   const declarations = Object.keys(exports).map((key) =>
     postcss.decl({
       prop: key,
       value: exports[key],
-      raws: { before: '\n  ' },
-    }),
-  )
+      raws: { before: "\n  " },
+    })
+  );
 
   if (declarations.length === 0) {
-    return []
+    return [];
   }
   const rule = !asAtRule
     ? postcss.rule({
         selector: `:export`,
-        raws: { after: '\n' },
+        raws: { after: "\n" },
       })
     : postcss.atRule({
-        name: 'icss-export',
-        raws: { after: '\n' },
-      })
+        name: "icss-export",
+        raws: { after: "\n" },
+      });
 
-  rule.append(declarations)
+  rule.append(declarations);
 
-  return [rule]
-}
+  return [rule];
+};
 
 const createICSSRules = (imports, exports, postcss, asAtRule) => [
   ...createImports(imports, postcss, asAtRule),
   ...createExports(exports, postcss, asAtRule),
-]
+];
 
-module.exports = createICSSRules
+module.exports = createICSSRules;

--- a/src/createICSSRules.js
+++ b/src/createICSSRules.js
@@ -1,4 +1,4 @@
-const createImports = (imports, postcss, asAtRule) => {
+const createImports = (imports, postcss, mode = "rule") => {
   return Object.keys(imports).map((path) => {
     const aliases = imports[path];
     const declarations = Object.keys(aliases).map((key) =>
@@ -11,16 +11,17 @@ const createImports = (imports, postcss, asAtRule) => {
 
     const hasDeclarations = declarations.length > 0;
 
-    const rule = !asAtRule
-      ? postcss.rule({
-          selector: `:import('${path}')`,
-          raws: { after: hasDeclarations ? "\n" : "" },
-        })
-      : postcss.atRule({
-          name: "icss-import",
-          params: `'${path}'`,
-          raws: { after: hasDeclarations ? "\n" : "" },
-        });
+    const rule =
+      mode === "rule"
+        ? postcss.rule({
+            selector: `:import('${path}')`,
+            raws: { after: hasDeclarations ? "\n" : "" },
+          })
+        : postcss.atRule({
+            name: "icss-import",
+            params: `'${path}'`,
+            raws: { after: hasDeclarations ? "\n" : "" },
+          });
 
     if (hasDeclarations) {
       rule.append(declarations);
@@ -30,7 +31,7 @@ const createImports = (imports, postcss, asAtRule) => {
   });
 };
 
-const createExports = (exports, postcss, asAtRule) => {
+const createExports = (exports, postcss, mode = "rule") => {
   const declarations = Object.keys(exports).map((key) =>
     postcss.decl({
       prop: key,
@@ -42,15 +43,16 @@ const createExports = (exports, postcss, asAtRule) => {
   if (declarations.length === 0) {
     return [];
   }
-  const rule = !asAtRule
-    ? postcss.rule({
-        selector: `:export`,
-        raws: { after: "\n" },
-      })
-    : postcss.atRule({
-        name: "icss-export",
-        raws: { after: "\n" },
-      });
+  const rule =
+    mode === "rule"
+      ? postcss.rule({
+          selector: `:export`,
+          raws: { after: "\n" },
+        })
+      : postcss.atRule({
+          name: "icss-export",
+          raws: { after: "\n" },
+        });
 
   rule.append(declarations);
 

--- a/src/createICSSRules.js
+++ b/src/createICSSRules.js
@@ -1,55 +1,65 @@
-const createImports = (imports, postcss) => {
+const createImports = (imports, postcss, asAtRule) => {
   return Object.keys(imports).map((path) => {
-    const aliases = imports[path];
+    const aliases = imports[path]
     const declarations = Object.keys(aliases).map((key) =>
       postcss.decl({
         prop: key,
         value: aliases[key],
-        raws: { before: "\n  " },
-      })
-    );
+        raws: { before: '\n  ' },
+      }),
+    )
 
-    const hasDeclarations = declarations.length > 0;
+    const hasDeclarations = declarations.length > 0
 
-    const rule = postcss.rule({
-      selector: `:import('${path}')`,
-      raws: { after: hasDeclarations ? "\n" : "" },
-    });
+    const rule = !asAtRule
+      ? postcss.rule({
+          selector: `:import('${path}')`,
+          raws: { after: hasDeclarations ? '\n' : '' },
+        })
+      : postcss.atRule({
+          name: 'icss-import',
+          params: `'${path}'`,
+          raws: { after: hasDeclarations ? '\n' : '' },
+        })
 
     if (hasDeclarations) {
-      rule.append(declarations);
+      rule.append(declarations)
     }
 
-    return rule;
-  });
-};
+    return rule
+  })
+}
 
-const createExports = (exports, postcss) => {
+const createExports = (exports, postcss, asAtRule) => {
   const declarations = Object.keys(exports).map((key) =>
     postcss.decl({
       prop: key,
       value: exports[key],
-      raws: { before: "\n  " },
-    })
-  );
+      raws: { before: '\n  ' },
+    }),
+  )
 
   if (declarations.length === 0) {
-    return [];
+    return []
   }
+  const rule = !asAtRule
+    ? postcss.rule({
+        selector: `:export`,
+        raws: { after: '\n' },
+      })
+    : postcss.atRule({
+        name: 'icss-export',
+        raws: { after: '\n' },
+      })
 
-  const rule = postcss
-    .rule({
-      selector: `:export`,
-      raws: { after: "\n" },
-    })
-    .append(declarations);
+  rule.append(declarations)
 
-  return [rule];
-};
+  return [rule]
+}
 
-const createICSSRules = (imports, exports, postcss) => [
-  ...createImports(imports, postcss),
-  ...createExports(exports, postcss),
-];
+const createICSSRules = (imports, exports, postcss, asAtRule) => [
+  ...createImports(imports, postcss, asAtRule),
+  ...createExports(exports, postcss, asAtRule),
+]
 
-module.exports = createICSSRules;
+module.exports = createICSSRules

--- a/src/extractICSS.js
+++ b/src/extractICSS.js
@@ -58,7 +58,7 @@ const extractICSS = (css, removeRules = true, mode = "auto") => {
 
     if (node.type === "atrule" && mode !== "rule") {
       if (node.name === "icss-import") {
-        const matches = balancedQuotes.exec(node.params.trim());
+        const matches = balancedQuotes.exec(node.params);
 
         if (matches) {
           addImports(node, matches[1]);

--- a/src/extractICSS.js
+++ b/src/extractICSS.js
@@ -1,76 +1,76 @@
-const importPattern = /^:import\(("[^"]*"|'[^']*'|[^"']+)\)$/
-const balancedQuotes = /^("[^"]*"|'[^']*'|[^"']+)$/
+const importPattern = /^:import\(("[^"]*"|'[^']*'|[^"']+)\)$/;
+const balancedQuotes = /^("[^"]*"|'[^']*'|[^"']+)$/;
 
 const getDeclsObject = (rule) => {
-  const object = {}
+  const object = {};
 
   rule.walkDecls((decl) => {
-    const before = decl.raws.before ? decl.raws.before.trim() : ''
+    const before = decl.raws.before ? decl.raws.before.trim() : "";
 
-    object[before + decl.prop] = decl.value
-  })
+    object[before + decl.prop] = decl.value;
+  });
 
-  return object
-}
+  return object;
+};
 /**
  *
  * @param {string} css
  * @param {boolean} removeRules
  * @param {auto|pseudo|atrule} mode
  */
-const extractICSS = (css, removeRules = true, mode = 'auto') => {
-  const icssImports = {}
-  const icssExports = {}
+const extractICSS = (css, removeRules = true, mode = "auto") => {
+  const icssImports = {};
+  const icssExports = {};
 
   function addImports(node, path) {
-    const unquoted = path.replace(/'|"/g, '')
+    const unquoted = path.replace(/'|"/g, "");
     icssImports[unquoted] = Object.assign(
       icssImports[unquoted] || {},
-      getDeclsObject(node),
-    )
+      getDeclsObject(node)
+    );
 
     if (removeRules) {
-      node.remove()
+      node.remove();
     }
   }
 
   function addExports(node) {
-    Object.assign(icssExports, getDeclsObject(node))
+    Object.assign(icssExports, getDeclsObject(node));
     if (removeRules) {
-      node.remove()
+      node.remove();
     }
   }
 
   css.each((node) => {
-    if (node.type === 'rule' && mode !== 'atrule') {
-      if (node.selector.slice(0, 7) === ':import') {
-        const matches = importPattern.exec(node.selector)
+    if (node.type === "rule" && mode !== "atrule") {
+      if (node.selector.slice(0, 7) === ":import") {
+        const matches = importPattern.exec(node.selector);
 
         if (matches) {
-          addImports(node, matches[1])
+          addImports(node, matches[1]);
         }
       }
 
-      if (node.selector === ':export') {
-        addExports(node)
+      if (node.selector === ":export") {
+        addExports(node);
       }
     }
 
-    if (node.type === 'atrule' && mode !== 'pseudo') {
-      if (node.name === 'icss-import') {
-        const matches = balancedQuotes.exec(node.params.trim())
+    if (node.type === "atrule" && mode !== "pseudo") {
+      if (node.name === "icss-import") {
+        const matches = balancedQuotes.exec(node.params.trim());
 
         if (matches) {
-          addImports(node, matches[1])
+          addImports(node, matches[1]);
         }
       }
-      if (node.name === 'icss-export') {
-        addExports(node)
+      if (node.name === "icss-export") {
+        addExports(node);
       }
     }
-  })
+  });
 
-  return { icssImports, icssExports }
-}
+  return { icssImports, icssExports };
+};
 
-module.exports = extractICSS
+module.exports = extractICSS;

--- a/src/extractICSS.js
+++ b/src/extractICSS.js
@@ -16,7 +16,7 @@ const getDeclsObject = (rule) => {
  *
  * @param {string} css
  * @param {boolean} removeRules
- * @param {auto|pseudo|atrule} mode
+ * @param {auto|rule|atrule} mode
  */
 const extractICSS = (css, removeRules = true, mode = "auto") => {
   const icssImports = {};
@@ -56,7 +56,7 @@ const extractICSS = (css, removeRules = true, mode = "auto") => {
       }
     }
 
-    if (node.type === "atrule" && mode !== "pseudo") {
+    if (node.type === "atrule" && mode !== "rule") {
       if (node.name === "icss-import") {
         const matches = balancedQuotes.exec(node.params.trim());
 

--- a/test/createICSSRules.test.js
+++ b/test/createICSSRules.test.js
@@ -1,60 +1,115 @@
-const postcss = require("postcss");
-const { createICSSRules } = require("../src");
+const postcss = require('postcss')
+const { createICSSRules } = require('../src')
 
-const run = (imports, exports) => {
+const run = (imports, exports, asAtRule) => {
   return postcss
     .root()
-    .append(createICSSRules(imports, exports, postcss))
-    .toString();
-};
+    .append(createICSSRules(imports, exports, postcss, asAtRule))
+    .toString()
+}
 
-test("create empty :import statement", () => {
+test('create empty :import statement', () => {
   expect(
     run(
       {
-        "path/file": {},
+        'path/file': {},
       },
-      {}
-    )
-  ).toEqual(":import('path/file') {}");
-});
+      {},
+    ),
+  ).toEqual(":import('path/file') {}")
+})
 
-test("create :import statement", () => {
+test('create :import statement', () => {
   expect(
     run(
       {
-        "path/file": {
-          e: "f",
+        'path/file': {
+          e: 'f',
         },
       },
-      {}
-    )
-  ).toEqual(":import('path/file') {\n  e: f\n}");
-});
+      {},
+    ),
+  ).toEqual(":import('path/file') {\n  e: f\n}")
+})
 
-test("create :export statement", () => {
+test('create :export statement', () => {
   expect(
     run(
       {},
       {
-        a: "b",
-        c: "d",
-      }
-    )
-  ).toEqual(":export {\n  a: b;\n  c: d\n}");
-});
+        a: 'b',
+        c: 'd',
+      },
+    ),
+  ).toEqual(':export {\n  a: b;\n  c: d\n}')
+})
 
-test("create :import and :export", () => {
+test('create :import and :export', () => {
   expect(
     run(
       {
         colors: {
-          a: "b",
+          a: 'b',
         },
       },
       {
-        c: "d",
-      }
-    )
-  ).toEqual(":import('colors') {\n  a: b\n}\n:export {\n  c: d\n}");
-});
+        c: 'd',
+      },
+    ),
+  ).toEqual(":import('colors') {\n  a: b\n}\n:export {\n  c: d\n}")
+})
+
+test('create empty @icss-import statement', () => {
+  expect(
+    run(
+      {
+        'path/file': {},
+      },
+      {},
+      true,
+    ),
+  ).toEqual("@icss-import 'path/file'")
+})
+
+test('create @icss-import statement', () => {
+  expect(
+    run(
+      {
+        'path/file': {
+          e: 'f',
+        },
+      },
+      {},
+      true,
+    ),
+  ).toEqual("@icss-import 'path/file' {\n  e: f\n}")
+})
+
+test('create @icss-export statement', () => {
+  expect(
+    run(
+      {},
+      {
+        a: 'b',
+        c: 'd',
+      },
+      true,
+    ),
+  ).toEqual('@icss-export {\n  a: b;\n  c: d\n}')
+})
+
+test('create @icss-import and @icss-export', () => {
+  expect(
+    run(
+      {
+        colors: {
+          a: 'b',
+        },
+      },
+      {
+        c: 'd',
+      },
+      true,
+    ),
+  ).toEqual("@icss-import 'colors' {\n  a: b\n}\n@icss-export {\n  c: d\n}")
+})

--- a/test/createICSSRules.test.js
+++ b/test/createICSSRules.test.js
@@ -1,10 +1,10 @@
 const postcss = require("postcss");
 const { createICSSRules } = require("../src");
 
-const run = (imports, exports, asAtRule) => {
+const run = (imports, exports, mode) => {
   return postcss
     .root()
-    .append(createICSSRules(imports, exports, postcss, asAtRule))
+    .append(createICSSRules(imports, exports, postcss, mode))
     .toString();
 };
 
@@ -66,7 +66,7 @@ test("create empty @icss-import statement", () => {
         "path/file": {},
       },
       {},
-      true
+      "atrule"
     )
   ).toEqual("@icss-import 'path/file'");
 });
@@ -80,7 +80,7 @@ test("create @icss-import statement", () => {
         },
       },
       {},
-      true
+      "atrule"
     )
   ).toEqual("@icss-import 'path/file' {\n  e: f\n}");
 });
@@ -93,7 +93,7 @@ test("create @icss-export statement", () => {
         a: "b",
         c: "d",
       },
-      true
+      "atrule"
     )
   ).toEqual("@icss-export {\n  a: b;\n  c: d\n}");
 });
@@ -109,7 +109,7 @@ test("create @icss-import and @icss-export", () => {
       {
         c: "d",
       },
-      true
+      "atrule"
     )
   ).toEqual("@icss-import 'colors' {\n  a: b\n}\n@icss-export {\n  c: d\n}");
 });

--- a/test/createICSSRules.test.js
+++ b/test/createICSSRules.test.js
@@ -1,115 +1,115 @@
-const postcss = require('postcss')
-const { createICSSRules } = require('../src')
+const postcss = require("postcss");
+const { createICSSRules } = require("../src");
 
 const run = (imports, exports, asAtRule) => {
   return postcss
     .root()
     .append(createICSSRules(imports, exports, postcss, asAtRule))
-    .toString()
-}
+    .toString();
+};
 
-test('create empty :import statement', () => {
+test("create empty :import statement", () => {
   expect(
     run(
       {
-        'path/file': {},
+        "path/file": {},
       },
-      {},
-    ),
-  ).toEqual(":import('path/file') {}")
-})
+      {}
+    )
+  ).toEqual(":import('path/file') {}");
+});
 
-test('create :import statement', () => {
+test("create :import statement", () => {
   expect(
     run(
       {
-        'path/file': {
-          e: 'f',
+        "path/file": {
+          e: "f",
         },
       },
-      {},
-    ),
-  ).toEqual(":import('path/file') {\n  e: f\n}")
-})
+      {}
+    )
+  ).toEqual(":import('path/file') {\n  e: f\n}");
+});
 
-test('create :export statement', () => {
+test("create :export statement", () => {
   expect(
     run(
       {},
       {
-        a: 'b',
-        c: 'd',
-      },
-    ),
-  ).toEqual(':export {\n  a: b;\n  c: d\n}')
-})
+        a: "b",
+        c: "d",
+      }
+    )
+  ).toEqual(":export {\n  a: b;\n  c: d\n}");
+});
 
-test('create :import and :export', () => {
+test("create :import and :export", () => {
   expect(
     run(
       {
         colors: {
-          a: 'b',
+          a: "b",
         },
       },
       {
-        c: 'd',
-      },
-    ),
-  ).toEqual(":import('colors') {\n  a: b\n}\n:export {\n  c: d\n}")
-})
+        c: "d",
+      }
+    )
+  ).toEqual(":import('colors') {\n  a: b\n}\n:export {\n  c: d\n}");
+});
 
-test('create empty @icss-import statement', () => {
+test("create empty @icss-import statement", () => {
   expect(
     run(
       {
-        'path/file': {},
+        "path/file": {},
       },
       {},
-      true,
-    ),
-  ).toEqual("@icss-import 'path/file'")
-})
+      true
+    )
+  ).toEqual("@icss-import 'path/file'");
+});
 
-test('create @icss-import statement', () => {
+test("create @icss-import statement", () => {
   expect(
     run(
       {
-        'path/file': {
-          e: 'f',
+        "path/file": {
+          e: "f",
         },
       },
       {},
-      true,
-    ),
-  ).toEqual("@icss-import 'path/file' {\n  e: f\n}")
-})
+      true
+    )
+  ).toEqual("@icss-import 'path/file' {\n  e: f\n}");
+});
 
-test('create @icss-export statement', () => {
+test("create @icss-export statement", () => {
   expect(
     run(
       {},
       {
-        a: 'b',
-        c: 'd',
+        a: "b",
+        c: "d",
       },
-      true,
-    ),
-  ).toEqual('@icss-export {\n  a: b;\n  c: d\n}')
-})
+      true
+    )
+  ).toEqual("@icss-export {\n  a: b;\n  c: d\n}");
+});
 
-test('create @icss-import and @icss-export', () => {
+test("create @icss-import and @icss-export", () => {
   expect(
     run(
       {
         colors: {
-          a: 'b',
+          a: "b",
         },
       },
       {
-        c: 'd',
+        c: "d",
       },
-      true,
-    ),
-  ).toEqual("@icss-import 'colors' {\n  a: b\n}\n@icss-export {\n  c: d\n}")
-})
+      true
+    )
+  ).toEqual("@icss-import 'colors' {\n  a: b\n}\n@icss-export {\n  c: d\n}");
+});

--- a/test/extractICSS.test.js
+++ b/test/extractICSS.test.js
@@ -1,112 +1,194 @@
-const postcss = require("postcss");
-const { extractICSS } = require("../src");
+const postcss = require('postcss')
+const { extractICSS } = require('../src')
 
-const runExtract = (input) => extractICSS(postcss.parse(input));
-const runCSS = (input, removeRules) => {
-  const css = postcss.parse(input);
-  extractICSS(css, removeRules);
-  return css.toString();
-};
+const runExtract = (input, mode) =>
+  extractICSS(postcss.parse(input), true, mode)
+const runCSS = (input, removeRules, mode) => {
+  const css = postcss.parse(input)
+  extractICSS(css, removeRules, mode)
+  return css.toString()
+}
 
-test("extract :import statements with identifier", () => {
-  expect(runExtract(":import(col.ors-2) {}")).toEqual({
+test('extract import statements with identifier', () => {
+  const expected = {
     icssImports: {
-      "col.ors-2": {},
+      'col.ors-2': {},
     },
     icssExports: {},
-  });
-});
+  }
+  expect(runExtract(':import(col.ors-2) {}')).toEqual(expected)
+  expect(runExtract('@icss-import col.ors-2 {}')).toEqual(expected)
+})
 
-test("extract :import statements with single quoted path", () => {
-  expect(runExtract(`:import('./colors.css') {}`)).toEqual({
+test('extract import statements with single quoted path', () => {
+  const expected = {
     icssImports: {
-      "./colors.css": {},
+      './colors.css': {},
     },
     icssExports: {},
-  });
-});
+  }
+  expect(runExtract(`:import('./colors.css') {}`)).toEqual(expected)
+  expect(runExtract(`@icss-import './colors.css'`)).toEqual(expected)
+})
 
-test("extract manually added :import", () => {
-  expect(runExtract(':import("./colors.css") {}')).toEqual({
+test('extract import with values', () => {
+  const expected = {
     icssImports: {
-      "./colors.css": {},
-    },
-    icssExports: {},
-  });
-});
-
-test("not extract :import with values", () => {
-  expect(
-    runExtract(":import(./colors.css) { i__blue: blue; i__red: red; }")
-  ).toEqual({
-    icssImports: {
-      "./colors.css": {
-        i__blue: "blue",
-        i__red: "red",
+      './colors.css': {
+        i__blue: 'blue',
+        i__red: 'red',
       },
     },
     icssExports: {},
-  });
-});
+  }
 
-test("extract :import statements manually created in postcss", () => {
-  const root = postcss.parse("");
+  expect(
+    runExtract(':import(./colors.css) { i__blue: blue; i__red: red; }'),
+  ).toEqual(expected)
+
+  expect(
+    runExtract('@icss-import ./colors.css { i__blue: blue; i__red: red; }'),
+  ).toEqual(expected)
+})
+
+test('extract :import statements manually created in postcss', () => {
+  const root = postcss.parse('')
   root.append(
     postcss
-      .rule({ selector: ":import(./colors.css)" })
-      .append(postcss.decl({ prop: "i__blue", value: "blue" }))
-      .append(postcss.decl({ prop: "i__red", value: "red" }))
-  );
+      .rule({ selector: ':import(./colors.css)' })
+      .append(postcss.decl({ prop: 'i__blue', value: 'blue' }))
+      .append(postcss.decl({ prop: 'i__red', value: 'red' })),
+  )
   expect(extractICSS(root)).toEqual({
     icssImports: {
-      "./colors.css": {
-        i__blue: "blue",
-        i__red: "red",
+      './colors.css': {
+        i__blue: 'blue',
+        i__red: 'red',
       },
     },
     icssExports: {},
-  });
-});
+  })
+})
+test('extract @icss-import statements manually created in postcss', () => {
+  const root = postcss.parse('')
+  root.append(
+    postcss
+      .atRule({ name: 'icss-import', params: './colors.css' })
+      .append(postcss.decl({ prop: 'i__blue', value: 'blue' }))
+      .append(postcss.decl({ prop: 'i__red', value: 'red' })),
+  )
+  expect(extractICSS(root)).toEqual({
+    icssImports: {
+      './colors.css': {
+        i__blue: 'blue',
+        i__red: 'red',
+      },
+    },
+    icssExports: {},
+  })
+})
 
-test("not extract invalid :import", () => {
+test('not extract invalid import', () => {
   expect(runExtract(":import(\\'./colors.css) {}")).toEqual({
     icssImports: {},
     icssExports: {},
-  });
-});
+  })
 
-test("extract :export", () => {
-  expect(runExtract(":export { blue: i__blue; red: i__red }")).toEqual({
+  expect(runExtract("@icss-import \\'./colors.css {}")).toEqual({
+    icssImports: {},
+    icssExports: {},
+  })
+})
+
+test('extract export', () => {
+  const expected = {
     icssImports: {},
     icssExports: {
-      blue: "i__blue",
-      red: "i__red",
+      blue: 'i__blue',
+      red: 'i__red',
     },
-  });
-});
+  }
 
-test("remove :import after extracting", () => {
-  expect(runCSS(":import(colors) {} .foo {}")).toEqual(".foo {}");
-});
+  expect(runExtract(':export { blue: i__blue; red: i__red }')).toEqual(expected)
+  expect(runExtract('@icss-export { blue: i__blue; red: i__red }')).toEqual(
+    expected,
+  )
+})
 
-test("remove :export after extracting", () => {
-  expect(runCSS(":export {} @media {}")).toEqual("@media {}");
-});
+test('remove import after extracting', () => {
+  expect(runCSS(':import(colors) {} .foo {}')).toEqual('.foo {}')
+  expect(runCSS('@icss-import(colors) {} .foo {}')).toEqual('.foo {}')
+})
 
-test("extract properties with underscore", () => {
-  expect(runExtract(":import(colors) {_a: b} :export { _c: d}")).toEqual({
+test('remove export after extracting', () => {
+  expect(runCSS(':export {} @media {}')).toEqual('@media {}')
+  expect(runCSS('@icss-export {} @media {}')).toEqual('@media {}')
+})
+
+test('extract properties with underscore', () => {
+  expect(runExtract(':import(colors) {_a: b} :export { _c: d}')).toEqual({
     icssImports: {
       colors: {
-        _a: "b",
+        _a: 'b',
       },
     },
     icssExports: {
-      _c: "d",
+      _c: 'd',
     },
-  });
-});
+  })
+})
 
-test("not remove rules from ast with removeRules=false", () => {
-  const fixture = ":import(colors) {_a: b} :export {_c: d} .foo {}";
-  expect(runCSS(fixture, false)).toEqual(fixture);
-});
+test('not remove rules from ast with removeRules=false', () => {
+  const fixture = ':import(colors) {_a: b} :export {_c: d} .foo {}'
+  expect(runCSS(fixture, false)).toEqual(fixture)
+})
+
+test('not process at-rules when mode is pseudo', () => {
+  expect(
+    runExtract(
+      `
+        :import(colors) {_a: b}
+        @icss-import("./other/colors") {_a: b}
+
+        :export {_c: d}
+        @icss-export { d: d}
+
+      `,
+      'pseudo',
+    ),
+  ).toEqual({
+    icssImports: {
+      colors: {
+        _a: 'b',
+      },
+    },
+    icssExports: {
+      _c: 'd',
+    },
+  })
+})
+
+test('not process at-rules when mode is atrule', () => {
+  expect(
+    runExtract(
+      `
+        :import(colors) {_a: b}
+        @icss-import "./other/colors" {_a: b}
+
+        :export {_c: d}
+        @icss-export { d: d}
+
+      `,
+      'atrule',
+    ),
+  ).toEqual({
+    icssImports: {
+      './other/colors': {
+        _a: 'b',
+      },
+    },
+    icssExports: {
+      d: 'd',
+    },
+  })
+})

--- a/test/extractICSS.test.js
+++ b/test/extractICSS.test.js
@@ -1,149 +1,151 @@
-const postcss = require('postcss')
-const { extractICSS } = require('../src')
+const postcss = require("postcss");
+const { extractICSS } = require("../src");
 
 const runExtract = (input, mode) =>
-  extractICSS(postcss.parse(input), true, mode)
+  extractICSS(postcss.parse(input), true, mode);
 const runCSS = (input, removeRules, mode) => {
-  const css = postcss.parse(input)
-  extractICSS(css, removeRules, mode)
-  return css.toString()
-}
+  const css = postcss.parse(input);
+  extractICSS(css, removeRules, mode);
+  return css.toString();
+};
 
-test('extract import statements with identifier', () => {
+test("extract import statements with identifier", () => {
   const expected = {
     icssImports: {
-      'col.ors-2': {},
+      "col.ors-2": {},
     },
     icssExports: {},
-  }
-  expect(runExtract(':import(col.ors-2) {}')).toEqual(expected)
-  expect(runExtract('@icss-import col.ors-2 {}')).toEqual(expected)
-})
+  };
+  expect(runExtract(":import(col.ors-2) {}")).toEqual(expected);
+  expect(runExtract("@icss-import col.ors-2 {}")).toEqual(expected);
+});
 
-test('extract import statements with single quoted path', () => {
+test("extract import statements with single quoted path", () => {
   const expected = {
     icssImports: {
-      './colors.css': {},
+      "./colors.css": {},
     },
     icssExports: {},
-  }
-  expect(runExtract(`:import('./colors.css') {}`)).toEqual(expected)
-  expect(runExtract(`@icss-import './colors.css'`)).toEqual(expected)
-})
+  };
+  expect(runExtract(`:import('./colors.css') {}`)).toEqual(expected);
+  expect(runExtract(`@icss-import './colors.css'`)).toEqual(expected);
+});
 
-test('extract import with values', () => {
+test("extract import with values", () => {
   const expected = {
     icssImports: {
-      './colors.css': {
-        i__blue: 'blue',
-        i__red: 'red',
+      "./colors.css": {
+        i__blue: "blue",
+        i__red: "red",
       },
     },
     icssExports: {},
-  }
+  };
 
   expect(
-    runExtract(':import(./colors.css) { i__blue: blue; i__red: red; }'),
-  ).toEqual(expected)
+    runExtract(":import(./colors.css) { i__blue: blue; i__red: red; }")
+  ).toEqual(expected);
 
   expect(
-    runExtract('@icss-import ./colors.css { i__blue: blue; i__red: red; }'),
-  ).toEqual(expected)
-})
+    runExtract("@icss-import ./colors.css { i__blue: blue; i__red: red; }")
+  ).toEqual(expected);
+});
 
-test('extract :import statements manually created in postcss', () => {
-  const root = postcss.parse('')
+test("extract :import statements manually created in postcss", () => {
+  const root = postcss.parse("");
   root.append(
     postcss
-      .rule({ selector: ':import(./colors.css)' })
-      .append(postcss.decl({ prop: 'i__blue', value: 'blue' }))
-      .append(postcss.decl({ prop: 'i__red', value: 'red' })),
-  )
+      .rule({ selector: ":import(./colors.css)" })
+      .append(postcss.decl({ prop: "i__blue", value: "blue" }))
+      .append(postcss.decl({ prop: "i__red", value: "red" }))
+  );
   expect(extractICSS(root)).toEqual({
     icssImports: {
-      './colors.css': {
-        i__blue: 'blue',
-        i__red: 'red',
+      "./colors.css": {
+        i__blue: "blue",
+        i__red: "red",
       },
     },
     icssExports: {},
-  })
-})
-test('extract @icss-import statements manually created in postcss', () => {
-  const root = postcss.parse('')
+  });
+});
+test("extract @icss-import statements manually created in postcss", () => {
+  const root = postcss.parse("");
   root.append(
     postcss
-      .atRule({ name: 'icss-import', params: './colors.css' })
-      .append(postcss.decl({ prop: 'i__blue', value: 'blue' }))
-      .append(postcss.decl({ prop: 'i__red', value: 'red' })),
-  )
+      .atRule({ name: "icss-import", params: "./colors.css" })
+      .append(postcss.decl({ prop: "i__blue", value: "blue" }))
+      .append(postcss.decl({ prop: "i__red", value: "red" }))
+  );
   expect(extractICSS(root)).toEqual({
     icssImports: {
-      './colors.css': {
-        i__blue: 'blue',
-        i__red: 'red',
+      "./colors.css": {
+        i__blue: "blue",
+        i__red: "red",
       },
     },
     icssExports: {},
-  })
-})
+  });
+});
 
-test('not extract invalid import', () => {
+test("not extract invalid import", () => {
   expect(runExtract(":import(\\'./colors.css) {}")).toEqual({
     icssImports: {},
     icssExports: {},
-  })
+  });
 
   expect(runExtract("@icss-import \\'./colors.css {}")).toEqual({
     icssImports: {},
     icssExports: {},
-  })
-})
+  });
+});
 
-test('extract export', () => {
+test("extract export", () => {
   const expected = {
     icssImports: {},
     icssExports: {
-      blue: 'i__blue',
-      red: 'i__red',
+      blue: "i__blue",
+      red: "i__red",
     },
-  }
+  };
 
-  expect(runExtract(':export { blue: i__blue; red: i__red }')).toEqual(expected)
-  expect(runExtract('@icss-export { blue: i__blue; red: i__red }')).toEqual(
-    expected,
-  )
-})
+  expect(runExtract(":export { blue: i__blue; red: i__red }")).toEqual(
+    expected
+  );
+  expect(runExtract("@icss-export { blue: i__blue; red: i__red }")).toEqual(
+    expected
+  );
+});
 
-test('remove import after extracting', () => {
-  expect(runCSS(':import(colors) {} .foo {}')).toEqual('.foo {}')
-  expect(runCSS('@icss-import(colors) {} .foo {}')).toEqual('.foo {}')
-})
+test("remove import after extracting", () => {
+  expect(runCSS(":import(colors) {} .foo {}")).toEqual(".foo {}");
+  expect(runCSS("@icss-import(colors) {} .foo {}")).toEqual(".foo {}");
+});
 
-test('remove export after extracting', () => {
-  expect(runCSS(':export {} @media {}')).toEqual('@media {}')
-  expect(runCSS('@icss-export {} @media {}')).toEqual('@media {}')
-})
+test("remove export after extracting", () => {
+  expect(runCSS(":export {} @media {}")).toEqual("@media {}");
+  expect(runCSS("@icss-export {} @media {}")).toEqual("@media {}");
+});
 
-test('extract properties with underscore', () => {
-  expect(runExtract(':import(colors) {_a: b} :export { _c: d}')).toEqual({
+test("extract properties with underscore", () => {
+  expect(runExtract(":import(colors) {_a: b} :export { _c: d}")).toEqual({
     icssImports: {
       colors: {
-        _a: 'b',
+        _a: "b",
       },
     },
     icssExports: {
-      _c: 'd',
+      _c: "d",
     },
-  })
-})
+  });
+});
 
-test('not remove rules from ast with removeRules=false', () => {
-  const fixture = ':import(colors) {_a: b} :export {_c: d} .foo {}'
-  expect(runCSS(fixture, false)).toEqual(fixture)
-})
+test("not remove rules from ast with removeRules=false", () => {
+  const fixture = ":import(colors) {_a: b} :export {_c: d} .foo {}";
+  expect(runCSS(fixture, false)).toEqual(fixture);
+});
 
-test('not process at-rules when mode is pseudo', () => {
+test("not process at-rules when mode is pseudo", () => {
   expect(
     runExtract(
       `
@@ -154,21 +156,21 @@ test('not process at-rules when mode is pseudo', () => {
         @icss-export { d: d}
 
       `,
-      'pseudo',
-    ),
+      "pseudo"
+    )
   ).toEqual({
     icssImports: {
       colors: {
-        _a: 'b',
+        _a: "b",
       },
     },
     icssExports: {
-      _c: 'd',
+      _c: "d",
     },
-  })
-})
+  });
+});
 
-test('not process at-rules when mode is atrule', () => {
+test("not process at-rules when mode is atrule", () => {
   expect(
     runExtract(
       `
@@ -179,16 +181,16 @@ test('not process at-rules when mode is atrule', () => {
         @icss-export { d: d}
 
       `,
-      'atrule',
-    ),
+      "atrule"
+    )
   ).toEqual({
     icssImports: {
-      './other/colors': {
-        _a: 'b',
+      "./other/colors": {
+        _a: "b",
       },
     },
     icssExports: {
-      d: 'd',
+      d: "d",
     },
-  })
-})
+  });
+});

--- a/test/extractICSS.test.js
+++ b/test/extractICSS.test.js
@@ -156,7 +156,7 @@ test("not process at-rules when mode is pseudo", () => {
         @icss-export { d: d}
 
       `,
-      "pseudo"
+      "rule"
     )
   ).toEqual({
     icssImports: {


### PR DESCRIPTION
Follow up to: https://github.com/webpack-contrib/css-loader/issues/1217#issuecomment-720677917 searches for both by default. This should allow for more flexibility with ICSS being used as an actual interchange format when sandwiched between tooling. E.g. Svelte automatically mangles `:import` and `:export` rules during it's style scoping pass (not configurable). At rules _should_ be safer, as tools generally have to leave unknown at-rules alone